### PR TITLE
fix: resolved RNSVGError from android

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -46,7 +46,7 @@
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "^3.24.0",
     "react-native-select-dropdown": "^3.4.0",
-    "react-native-svg": "^13.12.0",
+    "react-native-svg": "^13.4.0",
     "react-native-swiper": "^1.6.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 patchedDependencies:
   react-native@0.70.5:
     hash: rnbco5eodjkfp6ucueusre3z4i
@@ -128,7 +132,7 @@ importers:
         version: 4.2.14(react-native@0.70.5)(react@18.2.0)
       react-native-phone-input:
         specifier: ^1.3.7
-        version: 1.3.7(react-native@0.70.5)
+        version: 1.3.7(@react-native-picker/picker@2.5.0)(react-native@0.70.5)
       react-native-safe-area-context:
         specifier: 4.4.1
         version: 4.4.1(react-native@0.70.5)(react@18.2.0)
@@ -139,8 +143,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       react-native-svg:
-        specifier: ^13.12.0
-        version: 13.12.0(react-native@0.70.5)(react@18.2.0)
+        specifier: ^13.4.0
+        version: 13.4.0(react-native@0.70.5)(react@18.2.0)
       react-native-swiper:
         specifier: ^1.6.0
         version: 1.6.0
@@ -2854,6 +2858,16 @@ packages:
     resolution: {integrity: sha512-S7KdiWt0VgL93vy8sAlxPtyq8yNTRCNvoVJPkPlKzwuDY1Q5f+E0rsnNvfP0Y/UMhXAUnUo/THGR2qfrsJ9vNg==}
     dependencies:
       invariant: 2.2.4
+    dev: false
+
+  /@react-native-picker/picker@2.5.0(react-native@0.70.5)(react@18.2.0):
+    resolution: {integrity: sha512-AEZPKwXavmP4VkUUD6bskCrNF+zgd1RvsXJ208YewZSikGZCo0RLlnQxPDrdKoFpbigSYxbvRU5d8h3TzzeQ8Q==}
+    peerDependencies:
+      react: '>=16'
+      react-native: '>=0.57'
+    dependencies:
+      react: 18.2.0
+      react-native: 0.70.5(patch_hash=rnbco5eodjkfp6ucueusre3z4i)(@babel/core@7.20.5)(@babel/preset-env@7.20.2)(react@18.2.0)
     dev: false
 
   /@react-native/assets@1.0.0:
@@ -8605,12 +8619,13 @@ packages:
     resolution: {integrity: sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A==}
     dev: false
 
-  /react-native-phone-input@1.3.7(react-native@0.70.5):
+  /react-native-phone-input@1.3.7(@react-native-picker/picker@2.5.0)(react-native@0.70.5):
     resolution: {integrity: sha512-0mw8Y46SldiZtuVhWN0BUby3CU6qVqkQnWQv5WYziIak0u7o+UHQCKpKwhxLdH60H/w/Ktix8QD9DFgvHSLkvw==}
     peerDependencies:
       '@react-native-picker/picker': '>= 2.0'
       react-native: '>=0.69.9'
     dependencies:
+      '@react-native-picker/picker': 2.5.0(react-native@0.70.5)(react@18.2.0)
       google-libphonenumber: 3.2.33
       lodash: 4.17.21
       prop-types: 15.8.1
@@ -8643,8 +8658,8 @@ packages:
     resolution: {integrity: sha512-9xK1z4tYpwMxp3hsM0y1+xfqq/JoMh+l7sBsJ81b2eikFwT6ZbndFBqupQXrsQ1akce9hgC/10Nkzj0LjVjeXQ==}
     dev: false
 
-  /react-native-svg@13.12.0(react-native@0.70.5)(react@18.2.0):
-    resolution: {integrity: sha512-R+HvWfeps9z87CiXXlqIqr9OGPRKvZ7fCfUkDzDVv8wLMBzwi62sjZfAeCS+FxbVBPJ+xlvA4qfGjQZ7xRTBYw==}
+  /react-native-svg@13.4.0(react-native@0.70.5)(react@18.2.0):
+    resolution: {integrity: sha512-B3TwK+H0+JuRhYPzF21AgqMt4fjhCwDZ9QUtwNstT5XcslJBXC0FoTkdZo8IEb1Sv4suSqhZwlAY6lwOv3tHag==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -10468,7 +10483,3 @@ packages:
   /zod@3.20.0:
     resolution: {integrity: sha512-ZWxs7oM5ixoo1BMoxTNeDMYSih/F/FUnExsnRtHT04rG6q0Bd74TKS45RGXw07TOalOZyyzdKaYH38k8yTEv9A==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
Resolved the RNSVGError from android by installing: 
>pnpm i react-native-svg@13.4.0 --filter=@acme/expo

Error disappears when using react-native-svg version 13.4.0

Attached Below are svg components being rendered on a .tsx file format on android:

![368509538_1053883162439957_8098949716656587428_n](https://github.com/HansGabriel/TestTrek/assets/70251380/6d491417-743a-471c-acc5-e5debc1ae96e)


![368508631_1088623058774726_6262623661858426450_n](https://github.com/HansGabriel/TestTrek/assets/70251380/1b6a7517-13ff-4cbb-8173-24217789b57c)
