### PR TITLE
added: Discover page with items

### DIFF
--- a/apps/expo/src/components/Discover/DiscoverHomeCard.tsx
+++ b/apps/expo/src/components/Discover/DiscoverHomeCard.tsx
@@ -8,6 +8,8 @@ interface Props {
   imageSource: ImageSourcePropType;
   title: string;
   q: string;
+  date: Date;
+  plays: number;
   userImageSource: ImageSourcePropType;
   userName: string;
 }
@@ -23,7 +25,9 @@ const DiscoverHomeCard: FC<Props> = (props) => {
             source={props.imageSource}
           />
           <View className="absolute bottom-1 right-3 h-5 w-10 items-center justify-center rounded-md bg-purple-700">
-            <Text className="text-xs font-semibold text-white">16 Qs</Text>
+            <Text className="text-xs font-semibold text-white">
+              {props.q} Qs
+            </Text>
           </View>
         </View>
         <View className="flex-shrink-0 overflow-hidden p-3">

--- a/apps/expo/src/components/Discover/DiscoverScreenCard.tsx
+++ b/apps/expo/src/components/Discover/DiscoverScreenCard.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { Image, Text, View } from "react-native";
+import type { ImageSourcePropType } from "react-native";
+import image1 from "../../temp-data/discover/discover-images/image-source/image1.png";
+
+interface Props {
+  imageSource: ImageSourcePropType;
+  title: string;
+  q: string;
+  date: Date;
+  plays: number;
+  userImageSource: ImageSourcePropType;
+  userName: string;
+}
+
+function formatNumberToShortForm(num) {
+  if (num >= 1000000) {
+    return (num / 1000000).toFixed(1) + "m";
+  } else if (num >= 1000) {
+    return (num / 1000).toFixed(1) + "k";
+  }
+  return num.toString();
+}
+
+function monthDifference(dateFrom: Date, dateTo: Date) {
+  return (
+    (dateTo.getFullYear() - dateFrom.getFullYear()) * 12 +
+    dateTo.getMonth() -
+    dateFrom.getMonth()
+  );
+}
+
+function dayDifference(dateFrom: Date, dateTo: Date) {
+  const oneDay = 24 * 60 * 60 * 1000;
+  return Math.round(Math.abs((dateFrom.getTime() - dateTo.getTime()) / oneDay));
+}
+
+const DiscoverScreenCard: React.FC<Props> = (props) => {
+  const monthsAgo = monthDifference(new Date(props.date), new Date());
+  const daysAgo = dayDifference(new Date(props.date), new Date());
+
+  const timeAgo =
+    monthsAgo === 0
+      ? `${daysAgo} day${daysAgo !== 1 ? "s" : ""} ago`
+      : `${monthsAgo} month${monthsAgo !== 1 ? "s" : ""} ago`;
+  return (
+    <View className="w-90 mx-3 my-3 h-28 flex-row items-center">
+      <View className="h-28 flex-1 flex-row items-center overflow-hidden rounded-lg bg-white">
+        <View className="relative h-28 w-36">
+          <View className="absolute inset-0 bg-gray-400" />
+          <Image
+            className="absolute inset-0 h-28 w-36"
+            source={props.imageSource}
+          />
+          <View className="absolute bottom-3.5 right-3 h-5 w-10 items-center justify-center  rounded-md bg-purple-700">
+            <Text
+              style={{ fontSize: 10 }}
+              className=" overflow-hidden truncate font-semibold text-white"
+              numberOfLines={2}
+              ellipsizeMode="tail"
+            >
+              {props.q} Qs
+            </Text>
+          </View>
+        </View>
+        <View className="flex-1 flex-col justify-center overflow-hidden border-t border-r border-b border-gray-200 px-4 py-3">
+          <Text
+            className="flex-1 overflow-hidden truncate text-lg font-bold leading-7 text-black"
+            numberOfLines={2}
+            ellipsizeMode="tail"
+          >
+            {props.title}
+          </Text>
+          <View className="flex-row items-center overflow-hidden">
+            <Text
+              className="overflow-hidden truncate text-xs font-medium text-gray-400"
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {timeAgo}
+            </Text>
+            <Text className="mx-1 text-xs font-medium text-gray-400">•</Text>
+            <Text
+              className="overflow-hidden truncate text-xs font-medium text-gray-400"
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {formatNumberToShortForm(props.plays)} plays
+            </Text>
+          </View>
+          <View className="mt-3 flex-row items-center">
+            <Image className="h-5 w-5 rounded-full" source={image1} />
+            <Text
+              className="ml-1.5 overflow-hidden truncate text-xs font-semibold text-gray-600"
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {props.userName}
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default DiscoverScreenCard;

--- a/apps/expo/src/screens/discover.tsx
+++ b/apps/expo/src/screens/discover.tsx
@@ -1,11 +1,20 @@
 import React from "react";
-import { SafeAreaView } from "react-native";
+import { SafeAreaView, ScrollView, TouchableOpacity } from "react-native";
 import DiscoverScreenHeader from "../components/headers/DiscoverScreenHeader";
+import DiscoverScreenCard from "../components/discover/DiscoverScreenCard";
+import discoverCardList from "../temp-data/discover/discoverCardList";
 
 export const DiscoverScreen = () => {
   return (
     <SafeAreaView className="flex-1 flex-col">
       <DiscoverScreenHeader />
+      <ScrollView>
+        {discoverCardList.map((card, index) => (
+          <TouchableOpacity key={index}>
+            <DiscoverScreenCard {...card} />
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
     </SafeAreaView>
   );
 };

--- a/apps/expo/src/temp-data/discover/discoverCardList.tsx
+++ b/apps/expo/src/temp-data/discover/discoverCardList.tsx
@@ -1,40 +1,58 @@
-import DiscoverHomeCardType from "../types/discoverHomeCard";
 import image1 from "./discover-images/image-source/image1.png";
 import userImage1 from "./discover-images/user-image/user-image1.png";
 
-const discoverCardList: DiscoverHomeCardType[] = [
+const discoverCardList = [
   {
     imageSource: image1,
-    title: "Loooooongggggggggggggggg",
+    title: "Loooooggg",
     q: 1,
+    date: new Date("2022-12-11"),
+    plays: 5600,
     userImageSource: userImage1,
     userName: "user 1",
   },
   {
     imageSource: image1,
-    title: "Newwwww wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww2222",
-    q: 1,
+    title: "Newwwww wwwwwwwwww",
+    q: 2,
+    date: new Date("2022-10-11"),
+    plays: 5600,
     userImageSource: userImage1,
-    userName: "user 2222222222222222222222222222222",
+    userName: "user 22222",
   },
   {
     imageSource: image1,
     title: "Newers",
-    q: 1,
+    q: 12,
+    date: new Date("2022-1-11"),
+    plays: 5600,
     userImageSource: userImage1,
     userName: "user 3",
   },
   {
     imageSource: image1,
     title: "Legit Test",
-    q: 1,
+    q: 15,
+    date: new Date("2022-2-11"),
+    plays: 5600,
     userImageSource: userImage1,
-    userName: "user 4",
+    userName: 5600,
+  },
+  {
+    imageSource: image1,
+    title: "Random Stuff",
+    q: 11,
+    date: new Date("2022-12-11"),
+    plays: 5600,
+    userImageSource: userImage1,
+    userName: "user 5",
   },
   {
     imageSource: image1,
     title: "Random Stuff",
     q: 1,
+    date: new Date("2022-12-11"),
+    plays: 5600,
     userImageSource: userImage1,
     userName: "user 5",
   },


### PR DESCRIPTION
Added scrollable discover page, with logic to handle converting dates to XX months ago or days ago, and logic to convert number to shortcut displays (e.g 1100 becomes 1.1k). Item details are not final yet, may change in the future:



https://github.com/HansGabriel/TestTrek/assets/70251380/96498cac-c3ca-4f77-a012-5be2cd22a9fd


