### PR TITLE
refactor: view all now shows all items instead of 5

### DIFF
--- a/apps/expo/src/components/Discover/DiscoverHomeSection.tsx
+++ b/apps/expo/src/components/Discover/DiscoverHomeSection.tsx
@@ -9,7 +9,7 @@ import { SkeletonLoader } from "../loaders/SkeletonLoader";
 import HomeEmptyTest from "../home-empty-section/EmptyTest";
 
 const DiscoverHomeSection: FC = () => {
-  const { data } = trpc.test.getDiscoverTests.useQuery();
+  const { data } = trpc.test.getDiscoverTests.useQuery({ amountOfTests: 5 });
 
   const navigation = useNavigation();
 

--- a/apps/expo/src/components/HomeTestDisplayCard.tsx
+++ b/apps/expo/src/components/HomeTestDisplayCard.tsx
@@ -23,7 +23,7 @@ const HomeTestDisplayCard: FC<Props> = (props) => {
             className="absolute inset-0 h-28 w-full object-cover"
             source={props.imageSource}
           />
-          <View className="absolute bottom-1 right-3 h-5 w-10 items-center justify-center rounded-md bg-purple-700">
+          <View className="absolute bottom-3 right-3 h-5 w-10 items-center justify-center rounded-md bg-purple-700">
             <Text className="text-xs font-semibold text-white">
               {props.questions} Qs
             </Text>

--- a/apps/expo/src/components/top-collections/TopCollectionsHomeSection.tsx
+++ b/apps/expo/src/components/top-collections/TopCollectionsHomeSection.tsx
@@ -8,7 +8,9 @@ import { SkeletonLoader } from "../loaders/SkeletonLoader";
 import HomeEmptyCollection from "../home-empty-section/EmptyCollection";
 
 const TopCollectionsHomeSection: FC = () => {
-  const { data: topCollections } = trpc.collection.getTopCollections.useQuery();
+  const { data: topCollections } = trpc.collection.getTopCollections.useQuery({
+    amountOfColletions: 5,
+  });
 
   const navigation = useNavigation();
 

--- a/apps/expo/src/components/top-collections/TopCollectionsHomeSection.tsx
+++ b/apps/expo/src/components/top-collections/TopCollectionsHomeSection.tsx
@@ -9,7 +9,7 @@ import HomeEmptyCollection from "../home-empty-section/EmptyCollection";
 
 const TopCollectionsHomeSection: FC = () => {
   const { data: topCollections } = trpc.collection.getTopCollections.useQuery({
-    amountOfColletions: 5,
+    amountOfCollections: 5,
   });
 
   const navigation = useNavigation();

--- a/apps/expo/src/components/top-picks-tests/TopPicksHomeSection.tsx
+++ b/apps/expo/src/components/top-picks-tests/TopPicksHomeSection.tsx
@@ -8,7 +8,9 @@ import { IMAGE_PLACEHOLDER } from "../../constants";
 import { useNavigation } from "@react-navigation/native";
 
 const TopPicksHomeSection: FC = () => {
-  const { data: topPicksTest } = trpc.test.getTopPicks.useQuery();
+  const { data: topPicksTest } = trpc.test.getTopPicks.useQuery({
+    amountOfTests: 5,
+  });
 
   const navigation = useNavigation();
 

--- a/apps/expo/src/components/top-trekers/TopTrekersHomeSection.tsx
+++ b/apps/expo/src/components/top-trekers/TopTrekersHomeSection.tsx
@@ -11,7 +11,7 @@ import { useNavigation } from "@react-navigation/native";
 import { SkeletonLoader } from "../loaders/SkeletonLoader";
 
 const TopTrekersHomeSection: FC = () => {
-  const { data: topTrekers } = trpc.user.getTop.useQuery();
+  const { data: topTrekers } = trpc.user.getTop.useQuery({ amountOfUsers: 5 });
 
   const navigation = useNavigation();
 

--- a/apps/expo/src/components/trending-tests/TrendingTestsHomeSection.tsx
+++ b/apps/expo/src/components/trending-tests/TrendingTestsHomeSection.tsx
@@ -8,7 +8,9 @@ import { trpc } from "../../utils/trpc";
 import { useNavigation } from "@react-navigation/native";
 
 const TrendingTestsHomeSection: FC = () => {
-  const { data: trendingTests } = trpc.test.getTrendingTests.useQuery();
+  const { data: trendingTests } = trpc.test.getTrendingTests.useQuery({
+    amountOfTests: 5,
+  });
 
   const navigation = useNavigation();
 

--- a/apps/expo/src/components/view-all-display/tests/ViewAllTestDisplay.tsx
+++ b/apps/expo/src/components/view-all-display/tests/ViewAllTestDisplay.tsx
@@ -16,6 +16,7 @@ import { match } from "ts-pattern";
 import { IMAGE_PLACEHOLDER_LARGE } from "../../../constants";
 
 import type { PartialQuestion } from "../../../stores/useQuestionStore";
+import { Visibility } from "../../../../../../packages/db";
 
 type Props =
   | {
@@ -39,21 +40,35 @@ type FetchedData = TestsType | QuestionsType | PartialQuestion[] | undefined;
 
 export const ViewAllTestDisplay: FC<Props> = (props) => {
   let fetchedData: FetchedData = undefined;
+  let fetchedTestData:
+    | {
+        questions: { id: string }[];
+        user: { firstName: string; imageUrl: string | null; lastName: string };
+        title: string;
+        id: string;
+        description: string;
+        visibility: Visibility;
+        keywords: { id: string; name: string }[];
+        imageUrl: string;
+        createdAt: Date;
+        updatedAt: Date;
+      }[]
+    | undefined = undefined;
   let headerTitle = "";
 
   const navigation = useNavigation();
 
   if (props.testsFor == "discover") {
     const { data } = trpc.test.getDiscoverTests.useQuery();
-    fetchedData = data;
+    fetchedTestData = data;
     headerTitle = "Discover";
   } else if (props.testsFor == "trending") {
     const { data } = trpc.test.getTrendingTests.useQuery();
-    fetchedData = data;
+    fetchedTestData = data;
     headerTitle = "Trending";
   } else if (props.testsFor == "topPicks") {
     const { data } = trpc.test.getTopPicks.useQuery();
-    fetchedData = data;
+    fetchedTestData = data;
     headerTitle = "Top Picks";
   } else if (props.testsFor == "questions") {
     const { type } = props;
@@ -110,7 +125,7 @@ export const ViewAllTestDisplay: FC<Props> = (props) => {
             <>
               <FlashList
                 showsVerticalScrollIndicator={false}
-                data={fetchedData as TestsType}
+                data={fetchedTestData}
                 estimatedItemSize={100}
                 renderItem={({ item, index }) => {
                   const fullName = `${item.user.firstName} ${item.user.lastName}`;
@@ -157,7 +172,7 @@ const QuestionsList: FC<QuestionsListProps> = ({ questions }) => {
         renderItem={({ item: question, index }) => {
           return (
             <TouchableOpacity
-              className="my-2 mx-5 flex h-[105px] items-center justify-start"
+              className="mx-5 my-2 flex h-[105px] items-center justify-start"
               key={index}
             >
               <View className="flex shrink grow basis-0 items-center justify-start self-stretch rounded-xl border border-zinc-200 bg-white">

--- a/packages/api/src/router/collection.ts
+++ b/packages/api/src/router/collection.ts
@@ -2,6 +2,7 @@ import {
   collectionByUserIdSchema,
   collectionSortSchema,
   collectionsSchema,
+  highlightCollectionsInput,
 } from "@acme/schema/src/collection";
 import { router, protectedProcedure } from "../trpc";
 import { z } from "zod";
@@ -361,16 +362,20 @@ export const collectionRouter = router({
         },
       });
     }),
-  getTopCollections: protectedProcedure.query(({ ctx }) => {
-    return ctx.prisma.collection.findMany({
-      take: 5,
-      select: {
-        id: true,
-        title: true,
-        userId: true,
-        imageUrl: true,
-        tests: true,
-      },
-    });
-  }),
+  getTopCollections: protectedProcedure
+    .input(highlightCollectionsInput)
+    .query(({ ctx, input }) => {
+      return ctx.prisma.collection.findMany({
+        ...(input && input.amountOfColletions
+          ? { take: input.amountOfColletions }
+          : {}),
+        select: {
+          id: true,
+          title: true,
+          userId: true,
+          imageUrl: true,
+          tests: true,
+        },
+      });
+    }),
 });

--- a/packages/api/src/router/test.ts
+++ b/packages/api/src/router/test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
-import { testInputSchema } from "@acme/schema/src/test";
+import { highlightTestsInput, testInputSchema } from "@acme/schema/src/test";
 import { playersHighscoreSchema } from "@acme/schema/src/play";
 
 import { Prisma } from "@acme/db";
@@ -397,161 +397,111 @@ export const testRouter = router({
 
       return test;
     }),
-  getDiscoverTests: protectedProcedure.query(({ ctx }) => {
-    return ctx.prisma.test.findMany({
-      take: 5,
-      select: {
-        id: true,
-        title: true,
-        description: true,
-        imageUrl: true,
-        keywords: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-        questions: {
-          select: {
-            answer: true,
-            choices: {
-              select: {
-                id: true,
-                isCorrect: true,
-                text: true,
-              },
-            },
-            id: true,
-            image: true,
-            points: true,
-            possibleAnswers: true,
-            time: true,
-            title: true,
-            type: true,
-          },
-        },
-        collections: {
-          include: {
-            collection: true,
-          },
-        },
-        visibility: true,
-        user: {
-          select: {
-            imageUrl: true,
-            firstName: true,
-            lastName: true,
-          },
-        },
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
-  }),
 
-  getTrendingTests: protectedProcedure.query(({ ctx }) => {
-    return ctx.prisma.test.findMany({
-      take: 5,
-      select: {
-        id: true,
-        title: true,
-        description: true,
-        imageUrl: true,
-        keywords: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-        questions: {
-          select: {
-            answer: true,
-            choices: {
-              select: {
-                id: true,
-                isCorrect: true,
-                text: true,
-              },
+  getDiscoverTests: protectedProcedure
+    .input(highlightTestsInput)
+    .query(({ ctx, input }) => {
+      return ctx.prisma.test.findMany({
+        ...(input && input.amountOfTests ? { take: input.amountOfTests } : {}),
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          imageUrl: true,
+          keywords: {
+            select: {
+              id: true,
+              name: true,
             },
-            id: true,
-            image: true,
-            points: true,
-            possibleAnswers: true,
-            time: true,
-            title: true,
-            type: true,
           },
-        },
-        collections: {
-          include: {
-            collection: true,
+          questions: {
+            select: {
+              id: true,
+            },
           },
-        },
-        visibility: true,
-        user: {
-          select: {
-            imageUrl: true,
-            firstName: true,
-            lastName: true,
+          visibility: true,
+          user: {
+            select: {
+              imageUrl: true,
+              firstName: true,
+              lastName: true,
+            },
           },
+          createdAt: true,
+          updatedAt: true,
         },
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
-  }),
+      });
+    }),
 
-  getTopPicks: protectedProcedure.query(({ ctx }) => {
-    return ctx.prisma.test.findMany({
-      take: 5,
-      select: {
-        id: true,
-        title: true,
-        description: true,
-        imageUrl: true,
-        keywords: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-        questions: {
-          select: {
-            answer: true,
-            choices: {
-              select: {
-                id: true,
-                isCorrect: true,
-                text: true,
-              },
+  getTrendingTests: protectedProcedure
+    .input(highlightTestsInput)
+    .query(({ ctx, input }) => {
+      return ctx.prisma.test.findMany({
+        ...(input && input.amountOfTests ? { take: input.amountOfTests } : {}),
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          imageUrl: true,
+          keywords: {
+            select: {
+              id: true,
+              name: true,
             },
-            id: true,
-            image: true,
-            points: true,
-            possibleAnswers: true,
-            time: true,
-            title: true,
-            type: true,
           },
-        },
-        collections: {
-          include: {
-            collection: true,
+          questions: {
+            select: {
+              id: true,
+            },
           },
-        },
-        visibility: true,
-        user: {
-          select: {
-            imageUrl: true,
-            firstName: true,
-            lastName: true,
+          visibility: true,
+          user: {
+            select: {
+              imageUrl: true,
+              firstName: true,
+              lastName: true,
+            },
           },
+          createdAt: true,
+          updatedAt: true,
         },
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
-  }),
+      });
+    }),
+
+  getTopPicks: protectedProcedure
+    .input(highlightTestsInput)
+    .query(({ ctx, input }) => {
+      return ctx.prisma.test.findMany({
+        ...(input && input.amountOfTests ? { take: input.amountOfTests } : {}),
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          imageUrl: true,
+          keywords: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          questions: {
+            select: {
+              id: true,
+            },
+          },
+          visibility: true,
+          user: {
+            select: {
+              imageUrl: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+    }),
 
   getDetails: protectedProcedure
     .input(z.object({ testId: z.string() }))
@@ -572,7 +522,6 @@ export const testRouter = router({
       });
 
       const isOwner = test?.user.userId === ctx.auth.userId;
-
 
       const notOwner = test?.user.userId;
 

--- a/packages/api/src/router/user.ts
+++ b/packages/api/src/router/user.ts
@@ -1,4 +1,4 @@
-import { userStoredSchema } from "@acme/schema/src/user";
+import { highlightUsersInput, userStoredSchema } from "@acme/schema/src/user";
 import { z } from "zod";
 import { protectedProcedure, router } from "../trpc";
 import { Prisma } from "@acme/db";
@@ -6,19 +6,10 @@ import { PlayersHighscore } from "@acme/schema/src/types";
 
 export const useRouter = router({
   getTop: protectedProcedure
-    .input(
-      z
-        .object({
-          limit: z.number().optional().default(5),
-        })
-        .optional()
-        .default({
-          limit: 5,
-        }),
-    )
+    .input(highlightUsersInput)
     .query(({ ctx, input }) => {
-      const { limit } = input;
       return ctx.prisma.user.findMany({
+        ...(input && input.amountOfUsers ? { take: input.amountOfUsers } : {}),
         select: {
           id: true,
           userId: true,
@@ -26,7 +17,6 @@ export const useRouter = router({
           firstName: true,
           lastName: true,
         },
-        take: limit,
       });
     }),
 

--- a/packages/schema/src/collection.ts
+++ b/packages/schema/src/collection.ts
@@ -14,3 +14,9 @@ export const collectionByUserIdSchema = z.object({
   userId: z.string(),
   sortBy: z.enum(["newest", "oldest", "alphabetical"]).optional(),
 });
+
+export const highlightCollectionsInput = z
+  .object({
+    amountOfColletions: z.number().optional(),
+  })
+  .optional();

--- a/packages/schema/src/test.ts
+++ b/packages/schema/src/test.ts
@@ -64,6 +64,10 @@ export const testDetailsSchema = z.object({
   keywords: z.array(z.string().min(3).max(20)),
 });
 
+export const highlightTestsInput = z
+  .object({ amountOfTests: z.number().optional() })
+  .optional();
+
 export const testInputSchema = z.object({
   image: z.string({
     errorMap: () => ({

--- a/packages/schema/src/user.ts
+++ b/packages/schema/src/user.ts
@@ -25,6 +25,12 @@ export const userStoredSchema = z.object({
   lastName: z.string().min(1, "Last Name is required"),
 });
 
+export const highlightUsersInput = z
+  .object({
+    amountOfUsers: z.number().optional(),
+  })
+  .optional();
+
 export const userWebhookSchema = z
   .object({
     email_addresses: z


### PR DESCRIPTION
# Description

ViewAll now shows all tests/users/collections instead of 5; refactored highlight fetchers to include how many items to fetch

## Screenshots/Images

https://github.com/HansGabriel/TestTrek/assets/70251380/ed84cdf2-c27f-48f5-abaf-131a8de22138


