### PR TITLE
added: logic for trending and top picks test

### DIFF
--- a/packages/api/src/router/test.ts
+++ b/packages/api/src/router/test.ts
@@ -478,7 +478,9 @@ export const testRouter = router({
     .input(highlightTestsInput)
     .query(({ ctx, input }) => {
       return ctx.prisma.test.findMany({
-        ...(input && input.amountOfTests ? { take: input.amountOfTests } : {}),
+        ...(input && input.amountOfTests
+          ? { take: input.amountOfTests }
+          : { take: 50 }),
         select: {
           id: true,
           title: true,
@@ -506,11 +508,21 @@ export const testRouter = router({
           createdAt: true,
           updatedAt: true,
         },
-        orderBy: {
-          plays: {
-            _count: "desc",
+        orderBy: [
+          {
+            plays: {
+              _count: "desc",
+            },
           },
-        },
+          {
+            updatedAt: "desc",
+          },
+          {
+            questions: {
+              _count: "desc",
+            },
+          },
+        ],
       });
     }),
 
@@ -518,7 +530,9 @@ export const testRouter = router({
     .input(highlightTestsInput)
     .query(({ ctx, input }) => {
       return ctx.prisma.test.findMany({
-        ...(input && input.amountOfTests ? { take: input.amountOfTests } : {}),
+        ...(input && input.amountOfTests
+          ? { take: input.amountOfTests }
+          : { take: 50 }),
         select: {
           id: true,
           title: true,
@@ -546,11 +560,21 @@ export const testRouter = router({
           createdAt: true,
           updatedAt: true,
         },
-        orderBy: {
-          favoritedUsers: {
-            _count: "desc",
+        orderBy: [
+          {
+            favoritedUsers: {
+              _count: "desc",
+            },
           },
-        },
+          {
+            updatedAt: "desc",
+          },
+          {
+            questions: {
+              _count: "desc",
+            },
+          },
+        ],
       });
     }),
 

--- a/packages/api/src/router/tests/testQueries.test.ts
+++ b/packages/api/src/router/tests/testQueries.test.ts
@@ -256,11 +256,21 @@ describe("testRouter - queries", () => {
           createdAt: true,
           updatedAt: true,
         },
-        orderBy: {
-          plays: {
-            _count: "desc",
+        orderBy: [
+          {
+            plays: {
+              _count: "desc",
+            },
           },
-        },
+          {
+            updatedAt: "desc",
+          },
+          {
+            questions: {
+              _count: "desc",
+            },
+          },
+        ],
       });
     });
 
@@ -269,6 +279,7 @@ describe("testRouter - queries", () => {
       expect(result.length).toBe(2);
       expect(result[0]).toHaveProperty("id", "testId1");
       expect(ctx.prisma.test.findMany).toHaveBeenCalledWith({
+        take: 50,
         select: {
           id: true,
           title: true,
@@ -296,11 +307,21 @@ describe("testRouter - queries", () => {
           createdAt: true,
           updatedAt: true,
         },
-        orderBy: {
-          plays: {
-            _count: "desc",
+        orderBy: [
+          {
+            plays: {
+              _count: "desc",
+            },
           },
-        },
+          {
+            updatedAt: "desc",
+          },
+          {
+            questions: {
+              _count: "desc",
+            },
+          },
+        ],
       });
     });
   });
@@ -346,11 +367,21 @@ describe("testRouter - queries", () => {
           createdAt: true,
           updatedAt: true,
         },
-        orderBy: {
-          favoritedUsers: {
-            _count: "desc",
+        orderBy: [
+          {
+            favoritedUsers: {
+              _count: "desc",
+            },
           },
-        },
+          {
+            updatedAt: "desc",
+          },
+          {
+            questions: {
+              _count: "desc",
+            },
+          },
+        ],
       });
     });
 
@@ -360,6 +391,7 @@ describe("testRouter - queries", () => {
       expect(result[0]).toHaveProperty("id", "testId1");
       expect(result[1]).toHaveProperty("id", "testId2");
       expect(ctx.prisma.test.findMany).toHaveBeenCalledWith({
+        take: 50,
         select: {
           id: true,
           title: true,
@@ -387,11 +419,21 @@ describe("testRouter - queries", () => {
           createdAt: true,
           updatedAt: true,
         },
-        orderBy: {
-          favoritedUsers: {
-            _count: "desc",
+        orderBy: [
+          {
+            favoritedUsers: {
+              _count: "desc",
+            },
           },
-        },
+          {
+            updatedAt: "desc",
+          },
+          {
+            questions: {
+              _count: "desc",
+            },
+          },
+        ],
       });
     });
   });


### PR DESCRIPTION
# Description

added logic for trending test and top picks test: trending - amount of plays, top picks - amount of favorites

## Screenshots/Images

https://github.com/HansGabriel/TestTrek/assets/70251380/55d6e0d7-299b-487b-8794-173e686948a3




