### PR TITLE
refactor: limit to 50 for view all home tops; order by updatedAt for discover tests

### DIFF
--- a/packages/api/src/router/collection.ts
+++ b/packages/api/src/router/collection.ts
@@ -368,7 +368,7 @@ export const collectionRouter = router({
       return ctx.prisma.collection.findMany({
         ...(input && input.amountOfCollections
           ? { take: input.amountOfCollections }
-          : {}),
+          : { take: 50 }),
         select: {
           id: true,
           title: true,

--- a/packages/api/src/router/collection.ts
+++ b/packages/api/src/router/collection.ts
@@ -369,6 +369,9 @@ export const collectionRouter = router({
         ...(input && input.amountOfCollections
           ? { take: input.amountOfCollections }
           : { take: 50 }),
+        where: {
+          visibility: "public",
+        },
         select: {
           id: true,
           title: true,

--- a/packages/api/src/router/test.ts
+++ b/packages/api/src/router/test.ts
@@ -446,6 +446,9 @@ export const testRouter = router({
         ...(input && input.amountOfTests
           ? { take: input.amountOfTests }
           : { take: 50 }),
+        where: {
+          visibility: "public",
+        },
         select: {
           id: true,
           title: true,
@@ -472,6 +475,9 @@ export const testRouter = router({
           },
           createdAt: true,
           updatedAt: true,
+        },
+        orderBy: {
+          updatedAt: "desc",
         },
       });
     }),

--- a/packages/api/src/router/test.ts
+++ b/packages/api/src/router/test.ts
@@ -443,7 +443,9 @@ export const testRouter = router({
     .input(highlightTestsInput)
     .query(({ ctx, input }) => {
       return ctx.prisma.test.findMany({
-        ...(input && input.amountOfTests ? { take: input.amountOfTests } : {}),
+        ...(input && input.amountOfTests
+          ? { take: input.amountOfTests }
+          : { take: 50 }),
         select: {
           id: true,
           title: true,

--- a/packages/api/src/router/tests/collection.test.ts
+++ b/packages/api/src/router/tests/collection.test.ts
@@ -461,7 +461,7 @@ describe("collectionRouter", () => {
       expect(ctx.prisma.collection.findMany).toHaveBeenCalledWith({
         ...(input && input.amountOfCollections
           ? { take: input.amountOfCollections }
-          : {}),
+          : { take: 50 }),
         select: {
           id: true,
           title: true,

--- a/packages/api/src/router/tests/collection.test.ts
+++ b/packages/api/src/router/tests/collection.test.ts
@@ -462,6 +462,9 @@ describe("collectionRouter", () => {
         ...(input && input.amountOfCollections
           ? { take: input.amountOfCollections }
           : { take: 50 }),
+        where: {
+          visibility: "public",
+        },
         select: {
           id: true,
           title: true,

--- a/packages/api/src/router/tests/testQueries.test.ts
+++ b/packages/api/src/router/tests/testQueries.test.ts
@@ -184,6 +184,7 @@ describe("testRouter - queries", () => {
       expect(result[0]).toHaveProperty("id", "testId1");
       expect(result[1]).toHaveProperty("id", "testId2");
       expect(ctx.prisma.test.findMany).toHaveBeenCalledWith({
+        take: 50,
         select: {
           id: true,
           title: true,

--- a/packages/api/src/router/tests/testQueries.test.ts
+++ b/packages/api/src/router/tests/testQueries.test.ts
@@ -148,6 +148,9 @@ describe("testRouter - queries", () => {
       }
       expect(ctx.prisma.test.findMany).toHaveBeenCalledWith({
         take: input.amountOfTests,
+        where: {
+          visibility: "public",
+        },
         select: {
           id: true,
           title: true,
@@ -175,6 +178,9 @@ describe("testRouter - queries", () => {
           createdAt: true,
           updatedAt: true,
         },
+        orderBy: {
+          updatedAt: "desc",
+        },
       });
     });
 
@@ -185,6 +191,9 @@ describe("testRouter - queries", () => {
       expect(result[1]).toHaveProperty("id", "testId2");
       expect(ctx.prisma.test.findMany).toHaveBeenCalledWith({
         take: 50,
+        where: {
+          visibility: "public",
+        },
         select: {
           id: true,
           title: true,
@@ -211,6 +220,9 @@ describe("testRouter - queries", () => {
           },
           createdAt: true,
           updatedAt: true,
+        },
+        orderBy: {
+          updatedAt: "desc",
         },
       });
     });

--- a/packages/api/src/router/tests/user.test.ts
+++ b/packages/api/src/router/tests/user.test.ts
@@ -100,6 +100,22 @@ describe("useRouter", () => {
     });
   });
 
+  it("should handle getTop query with no input", async () => {
+    const input = {};
+    const result = await caller.getTop(input);
+    expect(result).toHaveLength(2);
+    expect(ctx.prisma.user.findMany).toHaveBeenCalledWith({
+      take: 50,
+      select: {
+        id: true,
+        userId: true,
+        imageUrl: true,
+        firstName: true,
+        lastName: true,
+      },
+    });
+  });
+
   it("should handle getUserById query", async () => {
     const input = { userId: "user1" };
     const result = await caller.getUserById(input);

--- a/packages/api/src/router/user.ts
+++ b/packages/api/src/router/user.ts
@@ -10,7 +10,9 @@ export const useRouter = router({
     .input(highlightUsersInput)
     .query(({ ctx, input }) => {
       return ctx.prisma.user.findMany({
-        ...(input && input.amountOfUsers ? { take: input.amountOfUsers } : {}),
+        ...(input && input.amountOfUsers
+          ? { take: input.amountOfUsers }
+          : { take: 50 }),
         select: {
           id: true,
           userId: true,


### PR DESCRIPTION
# Description

limited view all for home tops to 50 items; changed query logic to order discover tests by updatedAt
