### PR TITLE
added: backend for intializing algolia

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -36,6 +36,7 @@
     "@trpc/react-query": "^10.1.0",
     "@trpc/server": "^10.1.0",
     "@types/react-native-indicators": "^0.16.2",
+    "algoliasearch": "^4.20.0",
     "dayjs": "^1.11.9",
     "expo": "^48.0.6",
     "expo-auth-session": "^4.0.3",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,6 +15,7 @@
     "@acme/schema": "*",
     "@trpc/client": "^10.1.0",
     "@trpc/server": "^10.1.0",
+    "algoliasearch": "^4.20.0",
     "dotenv": "^16.3.1",
     "p-map": "^6.0.0",
     "shutterstock-api": "^1.1.35",

--- a/packages/api/src/router/algoliaSearch.ts
+++ b/packages/api/src/router/algoliaSearch.ts
@@ -1,9 +1,17 @@
-import { addAllTestsToAlgolia } from "../services/algoliaApiHandlers/algoliaApiAddAllHandlers";
+import {
+  addAllCollectionsToAlgolia,
+  addAllReviewersToAlgolia,
+  addAllTestsToAlgolia,
+  addAllUsersToAlgolia,
+} from "../services/algoliaApiHandlers/algoliaApiAddAllHandlers";
 import { router, protectedProcedure } from "../trpc";
 
 export const algoliaRouter = router({
-  addAllItemsToAlgolia: protectedProcedure.mutation(({ ctx }) => {
+  addAllTestsToAlgolia: protectedProcedure.mutation(({ ctx }) => {
     const queriedTests = ctx.prisma.test.findMany({
+      where: {
+        visibility: "public",
+      },
       select: {
         id: true,
         title: true,
@@ -37,5 +45,64 @@ export const algoliaRouter = router({
     });
 
     addAllTestsToAlgolia(queriedTests);
+  }),
+  addAllUsersToAlgolia: protectedProcedure.mutation(({ ctx }) => {
+    const queriedUsers = ctx.prisma.user.findMany({
+      select: {
+        id: true,
+        userId: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+        imageUrl: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    addAllUsersToAlgolia(queriedUsers);
+  }),
+  addAllCollectionsToAlgolia: protectedProcedure.mutation(({ ctx }) => {
+    const queriedCollections = ctx.prisma.collection.findMany({
+      where: {
+        visibility: "public",
+      },
+      select: {
+        id: true,
+        user: {
+          select: {
+            userId: true,
+            imageUrl: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+        title: true,
+        imageUrl: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    addAllCollectionsToAlgolia(queriedCollections);
+  }),
+  addAllReviewersToAlgolia: protectedProcedure.mutation(({ ctx }) => {
+    const queriedReviewers = ctx.prisma.reviewer.findMany({
+      where: { visibility: "public" },
+      select: {
+        id: true,
+        title: true,
+        imageUrl: true,
+        user: {
+          select: {
+            userId: true,
+            imageUrl: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    addAllReviewersToAlgolia(queriedReviewers);
   }),
 });

--- a/packages/api/src/router/algoliaSearch.ts
+++ b/packages/api/src/router/algoliaSearch.ts
@@ -1,0 +1,41 @@
+import { addAllTestsToAlgolia } from "../services/algoliaApiHandlers/algoliaApiAddAllHandlers";
+import { router, protectedProcedure } from "../trpc";
+
+export const algoliaRouter = router({
+  addAllItemsToAlgolia: protectedProcedure.mutation(({ ctx }) => {
+    const queriedTests = ctx.prisma.test.findMany({
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        imageUrl: true,
+        keywords: {
+          select: {
+            name: true,
+          },
+        },
+        questions: {
+          select: {
+            id: true,
+          },
+        },
+        visibility: true,
+        user: {
+          select: {
+            userId: true,
+            imageUrl: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+        createdAt: true,
+        updatedAt: true,
+      },
+      orderBy: {
+        updatedAt: "desc",
+      },
+    });
+
+    addAllTestsToAlgolia(queriedTests);
+  }),
+});

--- a/packages/api/src/router/index.ts
+++ b/packages/api/src/router/index.ts
@@ -8,6 +8,7 @@ import { useRouter } from "./user";
 import { playRouter } from "./play";
 import { gptApiRouter } from "./gptApi";
 import { reviewerRouter } from "./reviewer";
+import { algoliaRouter } from "./algoliaSearch";
 
 export const appRouter = router({
   auth: authRouter,
@@ -19,6 +20,7 @@ export const appRouter = router({
   play: playRouter,
   gptApi: gptApiRouter,
   reviewer: reviewerRouter,
+  algolia: algoliaRouter,
 });
 
 // export type definition of API

--- a/packages/api/src/services/algoliaApiHandlers/algoliaApiAddAllHandlers.ts
+++ b/packages/api/src/services/algoliaApiHandlers/algoliaApiAddAllHandlers.ts
@@ -1,0 +1,45 @@
+import { TestsForAlgolia } from "./algoliaTypes/algoliaTestsTypes";
+import algoliasearch from "algoliasearch";
+
+import "dotenv/config";
+
+const initializeAlgoliaClient = () => {
+  const applicationId = process.env.ALGOLIA_APP_ID;
+  const adminKey = process.env.ALGOLIA_ADMIN_KEY;
+
+  if (!applicationId || !adminKey) {
+    throw new Error("ALGOLIA_APP_ID and ALGOLIA_ADMIN_KEY are required");
+  }
+
+  return algoliasearch(applicationId, adminKey);
+};
+
+const parseTestsToAlgolia = async (data: Promise<TestsForAlgolia[]>) => {
+  const testsAlgoliaRecords = (await data).map(
+    ({ id, questions, ...rest }) => ({
+      objectID: id,
+      questions: questions?.length,
+      ...rest,
+    }),
+  );
+
+  return testsAlgoliaRecords;
+};
+
+export const addAllTestsToAlgolia = async (
+  queriedTests: Promise<TestsForAlgolia[]>,
+) => {
+  const data = queriedTests;
+
+  const testsAlgoliaRecords = parseTestsToAlgolia(data);
+
+  const client = initializeAlgoliaClient();
+  const testsIndex = client.initIndex("tests");
+
+  testsIndex.saveObjects(await testsAlgoliaRecords).then(({ objectIDs }) => {
+    console.log(objectIDs);
+    console.log("Tests Succesfully Added to Algolia Index");
+  });
+};
+
+const parseUsersToAlgolia = async () => {};

--- a/packages/api/src/services/algoliaApiHandlers/algoliaApiAddAllHandlers.ts
+++ b/packages/api/src/services/algoliaApiHandlers/algoliaApiAddAllHandlers.ts
@@ -1,4 +1,9 @@
-import { TestsForAlgolia } from "./algoliaTypes/algoliaTestsTypes";
+import {
+  CollectionsForAlgolia,
+  ReviewersForAlgolia,
+  TestsForAlgolia,
+  UsersForAlgolia,
+} from "./algoliaTypes/algoliaTestsTypes";
 import algoliasearch from "algoliasearch";
 
 import "dotenv/config";
@@ -42,4 +47,85 @@ export const addAllTestsToAlgolia = async (
   });
 };
 
-const parseUsersToAlgolia = async () => {};
+const parseUsersToAlgolia = async (data: Promise<UsersForAlgolia[]>) => {
+  const usersAlgoliaRecords = (await data).map(({ id, ...rest }) => ({
+    objectID: id,
+    ...rest,
+  }));
+
+  return usersAlgoliaRecords;
+};
+
+export const addAllUsersToAlgolia = async (
+  queriedUsers: Promise<UsersForAlgolia[]>,
+) => {
+  const data = queriedUsers;
+
+  const usersAlgoliaRecords = parseUsersToAlgolia(data);
+
+  const client = initializeAlgoliaClient();
+  const usersIndex = client.initIndex("users");
+
+  usersIndex.saveObjects(await usersAlgoliaRecords).then(({ objectIDs }) => {
+    console.log(objectIDs);
+    console.log("Users Succesfully Added to Algolia Index");
+  });
+};
+
+const parseCollectionsToAlgolia = async (
+  data: Promise<CollectionsForAlgolia[]>,
+) => {
+  const collectionsAlgoliaRecords = (await data).map(({ id, ...rest }) => ({
+    objectID: id,
+    ...rest,
+  }));
+
+  return collectionsAlgoliaRecords;
+};
+
+export const addAllCollectionsToAlgolia = async (
+  queriedCollections: Promise<CollectionsForAlgolia[]>,
+) => {
+  const data = queriedCollections;
+
+  const collectionsAlgoliaRecords = parseCollectionsToAlgolia(data);
+
+  const client = initializeAlgoliaClient();
+  const collectionsIndex = client.initIndex("collections");
+
+  collectionsIndex
+    .saveObjects(await collectionsAlgoliaRecords)
+    .then(({ objectIDs }) => {
+      console.log(objectIDs);
+      console.log("Collections Succesfully Added to Algolia Index");
+    });
+};
+
+const parseReviewersToAlgolia = async (
+  data: Promise<ReviewersForAlgolia[]>,
+) => {
+  const reviewersAlgoliaRecords = (await data).map(({ id, ...rest }) => ({
+    objectID: id,
+    ...rest,
+  }));
+
+  return reviewersAlgoliaRecords;
+};
+
+export const addAllReviewersToAlgolia = async (
+  queriedReviewers: Promise<ReviewersForAlgolia[]>,
+) => {
+  const data = queriedReviewers;
+
+  const reviewersAlgoliaRecords = parseReviewersToAlgolia(data);
+
+  const client = initializeAlgoliaClient();
+  const reviewersIndex = client.initIndex("reviewers");
+
+  reviewersIndex
+    .saveObjects(await reviewersAlgoliaRecords)
+    .then(({ objectIDs }) => {
+      console.log(objectIDs);
+      console.log("Reviewers Succesfully Added to Algolia Index");
+    });
+};

--- a/packages/api/src/services/algoliaApiHandlers/algoliaTypes/algoliaTestsTypes.ts
+++ b/packages/api/src/services/algoliaApiHandlers/algoliaTypes/algoliaTestsTypes.ts
@@ -24,3 +24,32 @@ export type TestsForAlgolia = {
   createdAt: Date;
   updatedAt: Date;
 };
+
+export type UsersForAlgolia = {
+  id: string;
+  userId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  imageUrl: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type CollectionsForAlgolia = {
+  id: string;
+  title: string;
+  imageUrl: string | null;
+  user?: UserSelect;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type ReviewersForAlgolia = {
+  id: string;
+  title: string;
+  imageUrl: string | null;
+  user?: UserSelect;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/packages/api/src/services/algoliaApiHandlers/algoliaTypes/algoliaTestsTypes.ts
+++ b/packages/api/src/services/algoliaApiHandlers/algoliaTypes/algoliaTestsTypes.ts
@@ -1,0 +1,26 @@
+type KeywordSelect = {
+  name: string;
+};
+
+type UserSelect = {
+  imageUrl?: string | null;
+  firstName: string;
+  lastName: string;
+};
+
+type QuestionSelect = {
+  id: string;
+};
+
+export type TestsForAlgolia = {
+  id: string;
+  title: string;
+  description: string;
+  imageUrl: string;
+  keywords?: KeywordSelect[];
+  questions?: QuestionSelect[];
+  visibility: "public" | "private";
+  user?: UserSelect;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/packages/api/src/services/unsplash.ts
+++ b/packages/api/src/services/unsplash.ts
@@ -25,7 +25,6 @@ export async function getUnsplashImages(
 
   const photos: any[] = query ? data.results : data;
 
-  // Map the Unsplash photo data to the StockImages type
   return photos.map((photo) => ({
     id: photo.id,
     description: photo.description || "No description", // Unsplash photos may not have a description

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,9 @@ importers:
       '@trpc/server':
         specifier: ^10.1.0
         version: 10.5.0
+      algoliasearch:
+        specifier: ^4.20.0
+        version: 4.20.0
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
@@ -469,6 +472,96 @@ importers:
 
 packages:
 
+  /@algolia/cache-browser-local-storage@4.20.0:
+    resolution: {integrity: sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==}
+    dependencies:
+      '@algolia/cache-common': 4.20.0
+    dev: false
+
+  /@algolia/cache-common@4.20.0:
+    resolution: {integrity: sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ==}
+    dev: false
+
+  /@algolia/cache-in-memory@4.20.0:
+    resolution: {integrity: sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==}
+    dependencies:
+      '@algolia/cache-common': 4.20.0
+    dev: false
+
+  /@algolia/client-account@4.20.0:
+    resolution: {integrity: sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==}
+    dependencies:
+      '@algolia/client-common': 4.20.0
+      '@algolia/client-search': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
+
+  /@algolia/client-analytics@4.20.0:
+    resolution: {integrity: sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==}
+    dependencies:
+      '@algolia/client-common': 4.20.0
+      '@algolia/client-search': 4.20.0
+      '@algolia/requester-common': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
+
+  /@algolia/client-common@4.20.0:
+    resolution: {integrity: sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==}
+    dependencies:
+      '@algolia/requester-common': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
+
+  /@algolia/client-personalization@4.20.0:
+    resolution: {integrity: sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==}
+    dependencies:
+      '@algolia/client-common': 4.20.0
+      '@algolia/requester-common': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
+
+  /@algolia/client-search@4.20.0:
+    resolution: {integrity: sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==}
+    dependencies:
+      '@algolia/client-common': 4.20.0
+      '@algolia/requester-common': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
+
+  /@algolia/logger-common@4.20.0:
+    resolution: {integrity: sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ==}
+    dev: false
+
+  /@algolia/logger-console@4.20.0:
+    resolution: {integrity: sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==}
+    dependencies:
+      '@algolia/logger-common': 4.20.0
+    dev: false
+
+  /@algolia/requester-browser-xhr@4.20.0:
+    resolution: {integrity: sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==}
+    dependencies:
+      '@algolia/requester-common': 4.20.0
+    dev: false
+
+  /@algolia/requester-common@4.20.0:
+    resolution: {integrity: sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng==}
+    dev: false
+
+  /@algolia/requester-node-http@4.20.0:
+    resolution: {integrity: sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==}
+    dependencies:
+      '@algolia/requester-common': 4.20.0
+    dev: false
+
+  /@algolia/transporter@4.20.0:
+    resolution: {integrity: sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==}
+    dependencies:
+      '@algolia/cache-common': 4.20.0
+      '@algolia/logger-common': 4.20.0
+      '@algolia/requester-common': 4.20.0
+    dev: false
+
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
@@ -478,7 +571,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.19
 
   /@babel/code-frame@7.10.4:
     resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
@@ -3056,7 +3149,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.19
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -3073,17 +3166,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.19
     dev: false
 
-  /@jridgewell/sourcemap-codec@1.4.14:
-    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
-  /@jridgewell/trace-mapping@0.3.17:
-    resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
 
   /@jridgewell/trace-mapping@0.3.19:
     resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
@@ -4505,6 +4589,25 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  /algoliasearch@4.20.0:
+    resolution: {integrity: sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==}
+    dependencies:
+      '@algolia/cache-browser-local-storage': 4.20.0
+      '@algolia/cache-common': 4.20.0
+      '@algolia/cache-in-memory': 4.20.0
+      '@algolia/client-account': 4.20.0
+      '@algolia/client-analytics': 4.20.0
+      '@algolia/client-common': 4.20.0
+      '@algolia/client-personalization': 4.20.0
+      '@algolia/client-search': 4.20.0
+      '@algolia/logger-common': 4.20.0
+      '@algolia/logger-console': 4.20.0
+      '@algolia/requester-browser-xhr': 4.20.0
+      '@algolia/requester-common': 4.20.0
+      '@algolia/requester-node-http': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
 
   /anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@types/react-native-indicators':
         specifier: ^0.16.2
         version: 0.16.2
+      algoliasearch:
+        specifier: ^4.20.0
+        version: 4.20.0
       dayjs:
         specifier: ^1.11.9
         version: 1.11.9


### PR DESCRIPTION
# Description

added algolia search intializers (tests, users, collections, and reviewers) to sync all db data to algolia account

NOTE: run ``` pnpm i ``` first since new packages were installed

## Code Snippets

To run the intializer:
```
cd packages/api
```
then

```
pnpm algolia-generate
```

