### PR TITLE
added: algolia intializers (backend implementation for now) (#187)

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -36,6 +36,7 @@
     "@trpc/react-query": "^10.1.0",
     "@trpc/server": "^10.1.0",
     "@types/react-native-indicators": "^0.16.2",
+    "algoliasearch": "^4.20.0",
     "dayjs": "^1.11.9",
     "expo": "^48.0.6",
     "expo-auth-session": "^4.0.3",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,17 +8,20 @@
     "clean": "rm -rf .turbo node_modules",
     "lint": "eslint . --ext .ts,.tsx",
     "type-check": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "algolia-generate": "ts-node src/services/algoliaApiHandlers/algoliaInitialize.ts"
   },
   "dependencies": {
     "@acme/db": "*",
     "@acme/schema": "*",
     "@trpc/client": "^10.1.0",
     "@trpc/server": "^10.1.0",
+    "algoliasearch": "^4.20.0",
     "dotenv": "^16.3.1",
     "p-map": "^6.0.0",
     "shutterstock-api": "^1.1.35",
     "superjson": "^1.9.1",
+    "ts-node": "^10.9.1",
     "unsplash-js": "^7.0.18",
     "zod": "^3.18.0"
   },

--- a/packages/api/src/services/algoliaApiHandlers/algoliaApiAddAllHandlers.ts
+++ b/packages/api/src/services/algoliaApiHandlers/algoliaApiAddAllHandlers.ts
@@ -1,0 +1,123 @@
+import {
+  CollectionsForAlgolia,
+  ReviewersForAlgolia,
+  TestsForAlgolia,
+  UsersForAlgolia,
+} from "./algoliaTypes/algoliaTestsTypes";
+import algoliasearch from "algoliasearch";
+
+import "dotenv/config";
+
+const initializeAlgoliaClient = () => {
+  const applicationId = process.env.ALGOLIA_APP_ID;
+  const adminKey = process.env.ALGOLIA_ADMIN_KEY;
+
+  if (!applicationId || !adminKey) {
+    throw new Error("ALGOLIA_APP_ID and ALGOLIA_ADMIN_KEY are required");
+  }
+
+  return algoliasearch(applicationId, adminKey);
+};
+
+const parseTestsToAlgolia = async (data: Promise<TestsForAlgolia[]>) => {
+  const testsAlgoliaRecords = (await data).map(
+    ({ id, questions, ...rest }) => ({
+      objectID: id,
+      questions: questions?.length,
+      ...rest,
+    }),
+  );
+
+  return testsAlgoliaRecords;
+};
+
+export const addAllTestsToAlgolia = async (
+  queriedTests: Promise<TestsForAlgolia[]>,
+) => {
+  const data = queriedTests;
+
+  const testsAlgoliaRecords = parseTestsToAlgolia(data);
+
+  const client = initializeAlgoliaClient();
+  const testsIndex = client.initIndex("tests");
+
+  testsIndex.saveObjects(await testsAlgoliaRecords).then(() => {
+    console.log("Tests Succesfully Added to Algolia Index");
+  });
+};
+
+const parseUsersToAlgolia = async (data: Promise<UsersForAlgolia[]>) => {
+  const usersAlgoliaRecords = (await data).map(({ id, ...rest }) => ({
+    objectID: id,
+    ...rest,
+  }));
+
+  return usersAlgoliaRecords;
+};
+
+export const addAllUsersToAlgolia = async (
+  queriedUsers: Promise<UsersForAlgolia[]>,
+) => {
+  const data = queriedUsers;
+
+  const usersAlgoliaRecords = parseUsersToAlgolia(data);
+
+  const client = initializeAlgoliaClient();
+  const usersIndex = client.initIndex("users");
+
+  usersIndex.saveObjects(await usersAlgoliaRecords).then(() => {
+    console.log("Users Succesfully Added to Algolia Index");
+  });
+};
+
+const parseCollectionsToAlgolia = async (
+  data: Promise<CollectionsForAlgolia[]>,
+) => {
+  const collectionsAlgoliaRecords = (await data).map(({ id, ...rest }) => ({
+    objectID: id,
+    ...rest,
+  }));
+
+  return collectionsAlgoliaRecords;
+};
+
+export const addAllCollectionsToAlgolia = async (
+  queriedCollections: Promise<CollectionsForAlgolia[]>,
+) => {
+  const data = queriedCollections;
+
+  const collectionsAlgoliaRecords = parseCollectionsToAlgolia(data);
+
+  const client = initializeAlgoliaClient();
+  const collectionsIndex = client.initIndex("collections");
+
+  collectionsIndex.saveObjects(await collectionsAlgoliaRecords).then(() => {
+    console.log("Collections Succesfully Added to Algolia Index");
+  });
+};
+
+const parseReviewersToAlgolia = async (
+  data: Promise<ReviewersForAlgolia[]>,
+) => {
+  const reviewersAlgoliaRecords = (await data).map(({ id, ...rest }) => ({
+    objectID: id,
+    ...rest,
+  }));
+
+  return reviewersAlgoliaRecords;
+};
+
+export const addAllReviewersToAlgolia = async (
+  queriedReviewers: Promise<ReviewersForAlgolia[]>,
+) => {
+  const data = queriedReviewers;
+
+  const reviewersAlgoliaRecords = parseReviewersToAlgolia(data);
+
+  const client = initializeAlgoliaClient();
+  const reviewersIndex = client.initIndex("reviewers");
+
+  reviewersIndex.saveObjects(await reviewersAlgoliaRecords).then(() => {
+    console.log("Reviewers Succesfully Added to Algolia Index");
+  });
+};

--- a/packages/api/src/services/algoliaApiHandlers/algoliaInitialize.ts
+++ b/packages/api/src/services/algoliaApiHandlers/algoliaInitialize.ts
@@ -1,0 +1,113 @@
+import {
+  addAllCollectionsToAlgolia,
+  addAllReviewersToAlgolia,
+  addAllTestsToAlgolia,
+  addAllUsersToAlgolia,
+} from "./algoliaApiAddAllHandlers";
+import { prisma } from "@acme/db";
+
+const initializeAlgolia = async () => {
+  try {
+    console.log("Running initialization tasks...");
+    await addAllTestsToAlgolia(
+      prisma.test.findMany({
+        where: {
+          visibility: "public",
+        },
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          imageUrl: true,
+          keywords: {
+            select: {
+              name: true,
+            },
+          },
+          questions: {
+            select: {
+              id: true,
+            },
+          },
+          visibility: true,
+          user: {
+            select: {
+              userId: true,
+              imageUrl: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+          createdAt: true,
+          updatedAt: true,
+        },
+        orderBy: {
+          updatedAt: "desc",
+        },
+      }),
+    );
+
+    await addAllUsersToAlgolia(
+      prisma.user.findMany({
+        select: {
+          id: true,
+          userId: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+          imageUrl: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      }),
+    );
+
+    await addAllCollectionsToAlgolia(
+      prisma.collection.findMany({
+        where: {
+          visibility: "public",
+        },
+        select: {
+          id: true,
+          user: {
+            select: {
+              userId: true,
+              imageUrl: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+          title: true,
+          imageUrl: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      }),
+    );
+
+    await addAllReviewersToAlgolia(
+      prisma.reviewer.findMany({
+        where: { visibility: "public" },
+        select: {
+          id: true,
+          title: true,
+          imageUrl: true,
+          user: {
+            select: {
+              userId: true,
+              imageUrl: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+          createdAt: true,
+          updatedAt: true,
+        },
+      }),
+    );
+  } catch (error) {
+    console.error("Error during initialization:", error);
+  }
+};
+
+initializeAlgolia();

--- a/packages/api/src/services/algoliaApiHandlers/algoliaTypes/algoliaTestsTypes.ts
+++ b/packages/api/src/services/algoliaApiHandlers/algoliaTypes/algoliaTestsTypes.ts
@@ -1,0 +1,55 @@
+type KeywordSelect = {
+  name: string;
+};
+
+type UserSelect = {
+  imageUrl?: string | null;
+  firstName: string;
+  lastName: string;
+};
+
+type QuestionSelect = {
+  id: string;
+};
+
+export type TestsForAlgolia = {
+  id: string;
+  title: string;
+  description: string;
+  imageUrl: string;
+  keywords?: KeywordSelect[];
+  questions?: QuestionSelect[];
+  visibility: "public" | "private";
+  user?: UserSelect;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type UsersForAlgolia = {
+  id: string;
+  userId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  imageUrl: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type CollectionsForAlgolia = {
+  id: string;
+  title: string;
+  imageUrl: string | null;
+  user?: UserSelect;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type ReviewersForAlgolia = {
+  id: string;
+  title: string;
+  imageUrl: string | null;
+  user?: UserSelect;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/packages/api/src/services/unsplash.ts
+++ b/packages/api/src/services/unsplash.ts
@@ -25,7 +25,6 @@ export async function getUnsplashImages(
 
   const photos: any[] = query ? data.results : data;
 
-  // Map the Unsplash photo data to the StockImages type
   return photos.map((photo) => ({
     id: photo.id,
     description: photo.description || "No description", // Unsplash photos may not have a description

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "index.ts", "transformer.ts", "globals.d.ts"]
+  "include": ["src", "index.ts", "transformer.ts", "globals.d.ts"],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@types/react-native-indicators':
         specifier: ^0.16.2
         version: 0.16.2
+      algoliasearch:
+        specifier: ^4.20.0
+        version: 4.20.0
       dayjs:
         specifier: ^1.11.9
         version: 1.11.9
@@ -394,6 +397,9 @@ importers:
       '@trpc/server':
         specifier: ^10.1.0
         version: 10.5.0
+      algoliasearch:
+        specifier: ^4.20.0
+        version: 4.20.0
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
@@ -416,6 +422,9 @@ importers:
       eslint:
         specifier: ^8.28.0
         version: 8.29.0
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@types/node@18.15.11)(typescript@4.9.4)
       typescript:
         specifier: ^4.9.3
         version: 4.9.4
@@ -469,6 +478,96 @@ importers:
 
 packages:
 
+  /@algolia/cache-browser-local-storage@4.20.0:
+    resolution: {integrity: sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==}
+    dependencies:
+      '@algolia/cache-common': 4.20.0
+    dev: false
+
+  /@algolia/cache-common@4.20.0:
+    resolution: {integrity: sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ==}
+    dev: false
+
+  /@algolia/cache-in-memory@4.20.0:
+    resolution: {integrity: sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==}
+    dependencies:
+      '@algolia/cache-common': 4.20.0
+    dev: false
+
+  /@algolia/client-account@4.20.0:
+    resolution: {integrity: sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==}
+    dependencies:
+      '@algolia/client-common': 4.20.0
+      '@algolia/client-search': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
+
+  /@algolia/client-analytics@4.20.0:
+    resolution: {integrity: sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==}
+    dependencies:
+      '@algolia/client-common': 4.20.0
+      '@algolia/client-search': 4.20.0
+      '@algolia/requester-common': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
+
+  /@algolia/client-common@4.20.0:
+    resolution: {integrity: sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==}
+    dependencies:
+      '@algolia/requester-common': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
+
+  /@algolia/client-personalization@4.20.0:
+    resolution: {integrity: sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==}
+    dependencies:
+      '@algolia/client-common': 4.20.0
+      '@algolia/requester-common': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
+
+  /@algolia/client-search@4.20.0:
+    resolution: {integrity: sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==}
+    dependencies:
+      '@algolia/client-common': 4.20.0
+      '@algolia/requester-common': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
+
+  /@algolia/logger-common@4.20.0:
+    resolution: {integrity: sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ==}
+    dev: false
+
+  /@algolia/logger-console@4.20.0:
+    resolution: {integrity: sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==}
+    dependencies:
+      '@algolia/logger-common': 4.20.0
+    dev: false
+
+  /@algolia/requester-browser-xhr@4.20.0:
+    resolution: {integrity: sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==}
+    dependencies:
+      '@algolia/requester-common': 4.20.0
+    dev: false
+
+  /@algolia/requester-common@4.20.0:
+    resolution: {integrity: sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng==}
+    dev: false
+
+  /@algolia/requester-node-http@4.20.0:
+    resolution: {integrity: sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==}
+    dependencies:
+      '@algolia/requester-common': 4.20.0
+    dev: false
+
+  /@algolia/transporter@4.20.0:
+    resolution: {integrity: sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==}
+    dependencies:
+      '@algolia/cache-common': 4.20.0
+      '@algolia/logger-common': 4.20.0
+      '@algolia/requester-common': 4.20.0
+    dev: false
+
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
@@ -478,7 +577,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.19
 
   /@babel/code-frame@7.10.4:
     resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
@@ -1979,6 +2078,13 @@ packages:
       csstype: 3.1.1
     dev: false
 
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
   /@egjs/hammerjs@2.0.17:
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
@@ -3056,7 +3162,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.19
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -3073,23 +3179,21 @@ packages:
       '@jridgewell/trace-mapping': 0.3.19
     dev: false
 
-  /@jridgewell/sourcemap-codec@1.4.14:
-    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
-  /@jridgewell/trace-mapping@0.3.17:
-    resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
 
   /@jridgewell/trace-mapping@0.3.19:
     resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /@manypkg/cli@0.19.2:
     resolution: {integrity: sha512-DXx/P1lyunNoFWwOj1MWBucUhaIJljoiAGOpO2fE0GKMBCI6EZBZD0Up1+fQZoXBecKXRgV9mGgLvIB2fOQ0KQ==}
@@ -3869,6 +3973,22 @@ packages:
     resolution: {integrity: sha512-AJ4ckDpnN8xuqWBox68KDTFpG12ZxKkW7fi9XJ+TLtyyNyqOMVUvKH9070CdxhqBZjebTASryE+/6lntkDFQxA==}
     dev: false
 
+  /@tsconfig/node10@1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
+
   /@types/babel__core@7.20.2:
     resolution: {integrity: sha512-pNpr1T1xLUc2l3xJKuPtsEky3ybxN3m4fJkknfIpTCTfIZCDW57oAg+EfCgIIp2rvCe0Wn++/FfodDS4YXxBwA==}
     dependencies:
@@ -4468,13 +4588,11 @@ packages:
   /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
-    dev: false
 
   /acorn@8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: false
 
   /acorn@8.8.2:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
@@ -4505,6 +4623,25 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  /algoliasearch@4.20.0:
+    resolution: {integrity: sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==}
+    dependencies:
+      '@algolia/cache-browser-local-storage': 4.20.0
+      '@algolia/cache-common': 4.20.0
+      '@algolia/cache-in-memory': 4.20.0
+      '@algolia/client-account': 4.20.0
+      '@algolia/client-analytics': 4.20.0
+      '@algolia/client-common': 4.20.0
+      '@algolia/client-personalization': 4.20.0
+      '@algolia/client-search': 4.20.0
+      '@algolia/logger-common': 4.20.0
+      '@algolia/logger-console': 4.20.0
+      '@algolia/requester-browser-xhr': 4.20.0
+      '@algolia/requester-common': 4.20.0
+      '@algolia/requester-node-http': 4.20.0
+      '@algolia/transporter': 4.20.0
+    dev: false
 
   /anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -4586,7 +4723,6 @@ packages:
 
   /arg@4.1.0:
     resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
-    dev: false
 
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -5616,6 +5752,10 @@ packages:
       - supports-color
       - ts-node
 
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
   /cross-fetch@3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
     dependencies:
@@ -5932,6 +6072,11 @@ packages:
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -11989,6 +12134,37 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
+  /ts-node@10.9.1(@types/node@18.15.11)(typescript@4.9.4):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.15.11
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      arg: 4.1.0
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /ts-object-utils@0.0.5:
     resolution: {integrity: sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==}
     dev: false
@@ -12345,6 +12521,10 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
     dev: false
+
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
 
   /v8-to-istanbul@9.1.3:
     resolution: {integrity: sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==}
@@ -12837,6 +13017,11 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}


### PR DESCRIPTION
* added: initial configuration for tests in algolia

* added: intialization for users, collections, reviewer in algolia

* refactored: added script to intialize algolia

* removed: algolia intializer from routers
# Description

added algolia search intializers (tests, users, collections, and reviewers) to sync all db data to algolia account

NOTE: run ``` pnpm i ``` first since new packages were installed

## Code Snippets

To run the intializer:
```
cd packages/api
```
then

```
pnpm algolia-generate
```