### PR TITLE
fix: realign save text and removed button shadow

### DIFF
--- a/apps/expo/src/screens/create-question/ChoiceCard.tsx
+++ b/apps/expo/src/screens/create-question/ChoiceCard.tsx
@@ -661,7 +661,7 @@ export const IdentificationCards = ({
           </View>
         ))}
 
-      <View className="w-[90%]">
+      <View className="w-[50%] self-center">
         <AppButton
           text="Add Choice"
           buttonColor="violet-600"
@@ -669,7 +669,7 @@ export const IdentificationCards = ({
           borderRadius="full"
           fontStyle="bold"
           textColor="white"
-          TOwidth="[45%]"
+          TOwidth="full"
           Vwidth="full"
           Vheight="12"
           onPress={addChoice}

--- a/apps/expo/src/screens/edit-personal-info.tsx
+++ b/apps/expo/src/screens/edit-personal-info.tsx
@@ -307,7 +307,7 @@ export const EditPersonalInfoScreen = () => {
           </View>
 
           {edit ? (
-            <View className="mt-24">
+            <View className="mt-auto w-[50%] self-center">
               <AppButton
                 text="Save"
                 buttonColor="violet-600"
@@ -315,9 +315,9 @@ export const EditPersonalInfoScreen = () => {
                 borderRadius="full"
                 fontStyle="bold"
                 textColor="white"
-                TOwidth="[50%]"
+                TOwidth="full"
                 Vwidth="full"
-                Vheight="16"
+                Vheight="12"
                 onPress={handleSubmit(submitEditedData)}
                 isLoading={isEditingUser}
               />

--- a/apps/expo/src/screens/play-test/TestCard.tsx
+++ b/apps/expo/src/screens/play-test/TestCard.tsx
@@ -137,7 +137,7 @@ export const IdentificationCard = ({
       <TextInput
         multiline={true}
         maxLength={75}
-        className="mx-5 my-8 h-[15%] flex-col items-center justify-center rounded-2xl border-b-2 bg-emerald-500 p-2 text-center text-lg font-bold leading-[28.80px] text-white"
+        className="mx-5 my-8 h-[15%] flex-col items-center justify-center rounded-2xl bg-emerald-500 p-2 text-center text-lg font-bold leading-[28.80px] text-white"
         selectionColor="white"
         value={answer}
         onChangeText={setAnswer}
@@ -155,7 +155,7 @@ export const IdentificationCard = ({
             {choices?.map((choice) => (
               <View
                 key={choice.id}
-                className={`inline-flex h-[50px] w-[85%] flex-col items-center justify-center rounded-2xl border-b-4 ${choice.styles}`}
+                className={`inline-flex h-[50px] w-[85%] flex-col items-center justify-center rounded-2xl ${choice.styles}`}
               >
                 <Text className="font-nunito-extrabold self-stretch text-center text-sm font-bold leading-[28.80px] text-white">
                   {choice.text}

--- a/apps/expo/src/screens/test-history/index.tsx
+++ b/apps/expo/src/screens/test-history/index.tsx
@@ -111,7 +111,7 @@ export const TestHistoryScreen: FC<TestHistoryProps> = ({
             textColor="white"
             TOwidth="full"
             Vwidth="full"
-            Vheight="10"
+            Vheight="12"
             onPress={goToScoreBoard}
             isLoading={isFetchingUser}
           />


### PR DESCRIPTION
# Description

Realign save button text in edit personal info screen
remove button shadow on identification cards

Linked with:
- elinaugo137/tes-271

## Code Snippets

None

## Screenshots/Images

None
