### PR TITLE
fix: failing tests for raw queries

### DIFF
--- a/packages/api/src/router/tests/testQueries.test.ts
+++ b/packages/api/src/router/tests/testQueries.test.ts
@@ -203,25 +203,25 @@ describe("testRouter - queries", () => {
     beforeEach(async () => {
       ctx.prisma.$queryRaw = vi.fn().mockResolvedValue([
         {
-          firstName: "John",
-          imageUrl: "img1.jpg",
+          user_first_name: "John",
+          user_image_url: "img1.jpg",
           id: "playerId1",
-          createdAt: new Date("2023-01-10T10:00:00Z"),
-          highScore: 95,
+          play_created_at: new Date("2023-01-10T10:00:00Z"),
+          high_score: 95,
         },
         {
-          firstName: "Doe",
-          imageUrl: "img2.jpg",
+          user_first_name: "Doe",
+          user_image_url: "img2.jpg",
           id: "playerId2",
-          createdAt: new Date("2023-01-05T10:00:00Z"),
-          highScore: 89,
+          play_created_at: new Date("2023-01-05T10:00:00Z"),
+          high_score: 89,
         },
         {
-          firstName: "Alice",
-          imageUrl: "img3.jpg",
+          user_first_name: "Alice",
+          user_image_url: "img3.jpg",
           id: "playerId3",
-          createdAt: new Date("2023-01-08T10:00:00Z"),
-          highScore: 92,
+          play_created_at: new Date("2023-01-08T10:00:00Z"),
+          high_score: 92,
         },
       ]);
     });

--- a/packages/api/src/router/tests/user.test.ts
+++ b/packages/api/src/router/tests/user.test.ts
@@ -172,30 +172,30 @@ describe("useRouter", () => {
           expect(ctx.prisma.$queryRaw).toHaveBeenCalledWith(
             //Note: the next lines `SELECT...LIMIT 3;` are CASE, SPACE, and NEXT-LINE SENSITIVE
             Prisma.sql`
-      SELECT
-        DISTINCT ON ("Play"."playerId")
-        "User"."firstName",
-        "User"."imageUrl",
-        "Play"."playerId" AS "id",
-        MAX("Play"."score") AS "highScore"
-      FROM
-        "Play"
-      JOIN
-        "User"
-      ON
-        "Play"."playerId" = "User"."userId"
-      WHERE
-        "Play"."isFinished" = TRUE
-        AND "Play"."testId" = ${item.testId}
-      GROUP BY
-        "Play"."playerId",
-        "User"."firstName",
-        "User"."imageUrl"
-      ORDER BY
-        "Play"."playerId",
-        "highScore" DESC
-      LIMIT 3;
-    `,
+                SELECT
+                  DISTINCT ON ("play"."player_id")
+                  "user"."user_first_name",
+                  "user"."user_image_url",
+                  "play"."player_id" AS "id",
+                  MAX("play"."play_score") AS "high_score"
+                FROM
+                  "play"
+                JOIN
+                  "user"
+                ON
+                  "play"."player_id" = "user"."clerk_user_id"
+                WHERE
+                  "play"."play_is_finished" = TRUE
+                  AND "play"."test_id" = ${item.testId}
+                GROUP BY
+                  "play"."player_id",
+                  "user"."user_first_name",
+                  "user"."user_image_url"
+                ORDER BY
+                  "play"."player_id",
+                  "high_score" DESC
+                LIMIT 3;
+              `,
           );
         },
         { concurrency: 5 },

--- a/packages/api/src/router/user.ts
+++ b/packages/api/src/router/user.ts
@@ -2,9 +2,10 @@ import { highlightUsersInput, userStoredSchema } from "@acme/schema/src/user";
 import { z } from "zod";
 import { protectedProcedure, router } from "../trpc";
 import { Prisma } from "@acme/db";
-import { PlayersHighscore } from "@acme/schema/src/types";
 import pMap from "p-map";
 import { updateUserInAlgolia } from "../services/algoliaApiHandlers/algoliaCudHandlers";
+
+import type { _PlayersHighscore } from "../types";
 
 export const useRouter = router({
   getTop: protectedProcedure
@@ -137,32 +138,42 @@ export const useRouter = router({
         userPlays,
         async (item) => {
           const top3Plays = await ctx.prisma
-            .$queryRaw<PlayersHighscore>(Prisma.sql`
-      SELECT
-        DISTINCT ON ("Play"."playerId")
-        "User"."firstName",
-        "User"."imageUrl",
-        "Play"."playerId" AS "id",
-        MAX("Play"."score") AS "highScore"
-      FROM
-        "Play"
-      JOIN
-        "User"
-      ON
-        "Play"."playerId" = "User"."userId"
-      WHERE
-        "Play"."isFinished" = TRUE
-        AND "Play"."testId" = ${item.testId}
-      GROUP BY
-        "Play"."playerId",
-        "User"."firstName",
-        "User"."imageUrl"
-      ORDER BY
-        "Play"."playerId",
-        "highScore" DESC
-      LIMIT 3;
-    `);
-
+            .$queryRaw<_PlayersHighscore[]>(
+              Prisma.sql`
+                SELECT
+                  DISTINCT ON ("play"."player_id")
+                  "user"."user_first_name",
+                  "user"."user_image_url",
+                  "play"."player_id" AS "id",
+                  MAX("play"."play_score") AS "high_score"
+                FROM
+                  "play"
+                JOIN
+                  "user"
+                ON
+                  "play"."player_id" = "user"."clerk_user_id"
+                WHERE
+                  "play"."play_is_finished" = TRUE
+                  AND "play"."test_id" = ${item.testId}
+                GROUP BY
+                  "play"."player_id",
+                  "user"."user_first_name",
+                  "user"."user_image_url"
+                ORDER BY
+                  "play"."player_id",
+                  "high_score" DESC
+                LIMIT 3;
+              `,
+            )
+            .then((plays) =>
+              plays.map((play) => ({
+                id: play.id,
+                createdAt: play.play_created_at,
+                highScore: play.high_score,
+                firstName: play.user_first_name,
+                imageUrl: play.user_image_url,
+              })),
+            );
           const userTop3Count = top3Plays.filter(
             (topPlay) => topPlay.id === ctx.auth.userId,
           ).length;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,0 +1,7 @@
+export type _PlayersHighscore = {
+  id: string;
+  user_first_name: string;
+  user_image_url: string;
+  play_created_at: Date;
+  high_score: number;
+};


### PR DESCRIPTION
# Description

The following PR fixes the following:
1. Raw queries for getting the top trekkers for a particular test by changing table names and fields to their snake case name
2. Raw queries for getting the number of tests a player is top 3 in by changing table names and fields to their snake case name
3. Change mocked tests for getting top trekker details
4. Change mocked tests for getting the number of tests a player is top 3 in

## Code Snippets

Added this type since raw SQL returns `snake_cased` keys for objects 
```ts
export type _PlayersHighscore = {
  id: string;
  user_first_name: string;
  user_image_url: string;
  play_created_at: Date;
  high_score: number;
};
```

## Screenshots/Images

N/A

# How Has This Been Tested?

Changed unit tests for raw sql queries
