### PR TITLE
refactor: changed question, choice limit, identification check logic (#283)

### DIFF
--- a/apps/expo/src/screens/create-question/index.tsx
+++ b/apps/expo/src/screens/create-question/index.tsx
@@ -781,7 +781,7 @@ export const CreateQuestionScreen: FC = () => {
                 placeholderTextColor={"#757575"}
                 onFocus={handleTextInputFocus}
                 multiline
-                maxLength={300}
+                maxLength={200}
               />
             </>
           </View>
@@ -883,7 +883,7 @@ export const CreateQuestionScreen: FC = () => {
                     </Text>
                     <TextInput
                       multiline={true}
-                      maxLength={150}
+                      maxLength={65}
                       className={`mx-5 mt-5 h-[50%] flex-col items-center justify-center rounded-2xl ${selectedChoice?.styles} p-2 text-center text-lg font-bold leading-[28.80px] text-white`}
                       selectionColor="white"
                       value={selectedChoice?.text}
@@ -894,9 +894,9 @@ export const CreateQuestionScreen: FC = () => {
                       placeholderTextColor="#FFFFFF"
                     />
                     {selectedChoice?.text &&
-                    selectedChoice?.text.length >= 150 ? (
+                    selectedChoice?.text.length >= 65 ? (
                       <Text className="mt-2 text-center text-red-500 ">
-                        You've reached the maximum of 150 characters.
+                        You've reached the maximum of 65 characters.
                       </Text>
                     ) : null}
 

--- a/apps/expo/src/screens/play-test/index.tsx
+++ b/apps/expo/src/screens/play-test/index.tsx
@@ -391,7 +391,8 @@ export const PlayTestScreen: FC<RootStackScreenProps<"PlayTest">> = ({
     }
 
     const isCorrectAnswer = question.choices.some(
-      (choice) => choice.text === answer,
+      (choice) =>
+        choice.text.trim().toLowerCase() === answer.trim().toLowerCase(),
     );
 
     if (question.type === "identification") {
@@ -536,8 +537,10 @@ export const PlayTestScreen: FC<RootStackScreenProps<"PlayTest">> = ({
 
     if (question.type === "identification") {
       const isCorrectAnswer = question.choices.some(
-        (choice) => choice.text === answer,
+        (choice) =>
+          choice.text.trim().toLowerCase() === answer.trim().toLowerCase(),
       );
+
       if (isCorrectAnswer) {
         const elapsedTime =
           countdownTimerRef.current?.elapsedTime ?? question.time;

--- a/packages/api/src/functions/gptHandlers.ts
+++ b/packages/api/src/functions/gptHandlers.ts
@@ -60,7 +60,7 @@ export const promptGenerators: {
     message,
     numChoices = 4,
     maxCharsForQuestion = 100,
-    maxCharsForChoice = 68,
+    maxCharsForChoice = 50,
   ) =>
     `Create a multiple choice question (maximum of ${maxCharsForQuestion} characters) about: "${message}" with ${numChoices} choices. Each choice must not exceed ${maxCharsForChoice} characters and there must be only 1 correct answer. Format as:
 Question: [Your question here]
@@ -71,14 +71,14 @@ ${timeAndPointsPrompt}`,
   identification: (
     message,
     maxCharsForQuestion = 100,
-    maxCharsForChoice = 68,
+    maxCharsForChoice = 50,
   ) =>
     `Create an identification question (maximum of ${maxCharsForQuestion} characters) based on: "${message}". The answer must not exceed ${maxCharsForChoice} characters. Format as:
 Question: [Your question here]
 Answer: [Your answer here]
 ${timeAndPointsPrompt}`,
 
-  trueOrFalse: (message, maxCharsForQuestion = 100, maxCharsForChoice = 68) =>
+  trueOrFalse: (message, maxCharsForQuestion = 100, maxCharsForChoice = 50) =>
     `Based on the information "${message}", generate a true or false question (maximum of ${maxCharsForQuestion} characters). The answer must not exceed ${maxCharsForChoice} characters. Format as:
 Question: [Your question here]
 Answer: [True/False]
@@ -88,7 +88,7 @@ ${timeAndPointsPrompt}`,
     message,
     numChoices = 4,
     maxCharsForQuestion = 100,
-    maxCharsForChoice = 68,
+    maxCharsForChoice = 50,
   ) =>
     `Create a multiselect question (maximum of ${maxCharsForQuestion} characters) about: "${message}" with ${numChoices} choices. The choices must not exceed ${maxCharsForChoice} characters and there must be atleast 1 correct answer. Multiple answers can be correct. Format as:
 Question: [Your question here]

--- a/packages/api/src/functions/randomQuestionsHandlers.ts
+++ b/packages/api/src/functions/randomQuestionsHandlers.ts
@@ -48,7 +48,7 @@ export const questionFormatGenerators: {
   multipleChoice: (
     numChoices = 4,
     maxCharsForQuestion = 100,
-    maxCharsForChoice = 68,
+    maxCharsForChoice = 50,
   ) => `separator\nQuestion: [Your question here, max ${maxCharsForQuestion} characters, and each choice below must not exceed ${maxCharsForChoice} characters]
   ${generateChoicesPrompt(
     numChoices,
@@ -57,13 +57,13 @@ export const questionFormatGenerators: {
   multiselect: (
     numChoices = 4,
     maxCharsForQuestion = 100,
-    maxCharsForChoice = 68,
+    maxCharsForChoice = 50,
   ) => `separator\nQuestion: [Your question here, max ${maxCharsForQuestion} characters, and each choice below must not exceed ${maxCharsForChoice} characters]
   ${generateChoicesPrompt(
     numChoices,
   )}\nAll Correct Answers: Options [Correct option numbers separated by commas (e.g., 1,3) and at least one correct answer] ${timeAndPointsPrompt}`,
 
-  identification: (maxCharsForQuestion = 100, maxCharsForChoice = 68) =>
+  identification: (maxCharsForQuestion = 100, maxCharsForChoice = 50) =>
     `separator\nQuestion: [Your question here, max ${maxCharsForQuestion} characters]\nAnswer: [Your answer here, max ${maxCharsForChoice} characters] ${timeAndPointsPrompt}`,
 
   trueOrFalse: (maxCharsForQuestion = 100) =>


### PR DESCRIPTION
# Description

Set input limit for questions to 200 and choices to 65; for ai, 100 for questions and 50 for choices; changed logic for checking identification to ignore leading and trailing white spaces and lowercase all characters

## Screenshots/Images

![405017023_264944979913699_5729488758215016292_n](https://github.com/HansGabriel/TestTrek/assets/70251380/70936fbd-9539-4e3f-a653-aa27a8b8c7c9)


![387340400_237512596030080_7463076996339683107_n](https://github.com/HansGabriel/TestTrek/assets/70251380/71bfbb9f-e989-4ce5-9ae4-78714746fc6e)

