### PR TITLE
TES-308: New reviewers not updating in discover reviewers home screen

### DIFF
--- a/apps/expo/src/screens/create-reviewer/index.tsx
+++ b/apps/expo/src/screens/create-reviewer/index.tsx
@@ -107,6 +107,9 @@ export const CreateReviewerScreen = ({
     isLoading: isCreatingReviewer,
     reset,
   } = trpc.reviewer.createReviewer.useMutation({
+    onSuccess: () => {
+      trpcUtils.reviewer.invalidate();
+    },
     onError: (error) => {
       errorToast({
         title: "Error",
@@ -137,7 +140,17 @@ export const CreateReviewerScreen = ({
     });
 
   const { mutate: updateReviewer, isLoading: isUpdatingReviewer } =
-    trpc.reviewer.updateReviewer.useMutation();
+    trpc.reviewer.updateReviewer.useMutation({
+      onSuccess: () => {
+        trpcUtils.reviewer.invalidate();
+      },
+      onError: (error) => {
+        errorToast({
+          title: "Error",
+          message: error.message,
+        });
+      },
+    });
 
   const getDisplayImage = () => {
     if (reviewerImage) {


### PR DESCRIPTION
# Description

Add cache invalidations to reviewer queries when creating and updating reviewere

## Code Snippets

Any small code snippet that might help the reviewer understand what's important

## Screenshots/Images

Make it easier for reviewers to see visually what you built, if it applies.

# How Has This Been Tested?

Did you write new tests? Did local test checks pass?
